### PR TITLE
Allow pass any parameter to pytest 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,4 +10,4 @@ jobs:
   main:
     uses: asottile/workflows/.github/workflows/tox.yml@v1.5.0
     with:
-      env: '["py38", "py39", "py310"]'
+      env: '["py38", "py39", "py310", "py311"]'

--- a/README.md
+++ b/README.md
@@ -169,6 +169,14 @@ try `detect-test-pollution --failing-test t.py::test_k --tests t.py`!
 afterwards you can use the normal mode of `detect-test-pollution` to find the
 failing pair.
 
+## extra pytest options
+
+any argument or option can be passed directly to pytest by adding them at the end of command:
+
+```console
+detect-test-pollution --fuzz --tests tests -m 'not qt_test'
+```
+
 ## supported test runners
 
 at the moment only `pytest` is supported -- though in theory the tool could

--- a/detect_test_pollution.py
+++ b/detect_test_pollution.py
@@ -74,7 +74,13 @@ def pytest_configure(config: pytest.Config) -> None:
 def _run_pytest(extra_pytest_opts: list[str], *args: str) -> None:
     # XXX: this is potentially difficult to debug? maybe --verbose?
     subprocess.check_call(
-        (sys.executable, '-mpytest', *PYTEST_OPTIONS, *extra_pytest_opts, *args),
+        (
+            sys.executable,
+            '-mpytest',
+            *PYTEST_OPTIONS,
+            *extra_pytest_opts,
+            *args,
+        ),
         stdout=subprocess.DEVNULL,
     )
 
@@ -106,7 +112,9 @@ def _common_testpath(testids: list[str]) -> str:
         return os.path.commonpath(paths) or '.'
 
 
-def _passed_with_testlist(path: str, test: str, testids: list[str], extra_pytest_opts: list[str]) -> bool:
+def _passed_with_testlist(
+        path: str, test: str, testids: list[str], extra_pytest_opts: list[str],
+) -> bool:
     with tempfile.TemporaryDirectory() as tmpdir:
         testids_filename = os.path.join(tmpdir, 'testids.txt')
         with open(testids_filename, 'w') as f:
@@ -197,7 +205,12 @@ def _fuzz(
             return 1
 
 
-def _bisect(testpath: str, failing_test: str, testids: list[str], extra_pytest_opts: list[str]) -> int:
+def _bisect(
+        testpath: str,
+        failing_test: str,
+        testids: list[str],
+        extra_pytest_opts: list[str],
+) -> int:
     if failing_test not in testids:
         print('-> failing test was not part of discovered tests!')
         return 1
@@ -215,7 +228,9 @@ def _bisect(testpath: str, failing_test: str, testids: list[str], extra_pytest_o
 
     # step 3: ensure test fails
     print('ensuring test fails with test group...')
-    if _passed_with_testlist(testpath, failing_test, testids, extra_pytest_opts):
+    if _passed_with_testlist(
+            testpath, failing_test, testids, extra_pytest_opts,
+    ):
         print('-> expected failure -- but it passed?')
         return 1
     else:
@@ -234,14 +249,18 @@ def _bisect(testpath: str, failing_test: str, testids: list[str], extra_pytest_o
         part1 = testids[:pivot]
         part2 = testids[pivot:]
 
-        if _passed_with_testlist(testpath, failing_test, part1, extra_pytest_opts):
+        if _passed_with_testlist(
+                testpath, failing_test, part1, extra_pytest_opts,
+        ):
             testids = part2
         else:
             testids = part1
 
     # step 5: make sure it still fails
     print('double checking we found it...')
-    if _passed_with_testlist(testpath, failing_test, testids, extra_pytest_opts):
+    if _passed_with_testlist(
+            testpath, failing_test, testids, extra_pytest_opts,
+    ):
         raise AssertionError('unreachable? unexpected pass? report a bug?')
     else:
         print(f'-> the polluting test is: {testids[0]}')
@@ -288,7 +307,13 @@ def main(argv: Sequence[str] | None = None) -> int:
     testpath = _common_testpath(testids)
 
     if args.fuzz:
-        return _fuzz(testpath, testids, args.tests, args.testids_file, extra_pytest_opts)
+        return _fuzz(
+            testpath,
+            testids,
+            args.tests,
+            args.testids_file,
+            extra_pytest_opts,
+        )
     else:
         return _bisect(testpath, args.failing_test, testids, extra_pytest_opts)
 

--- a/tests/detect_test_pollution_test.py
+++ b/tests/detect_test_pollution_test.py
@@ -128,13 +128,17 @@ def test_common_testpath(inputs, expected):
 def test_passed_with_testlist_failing(tmp_path):
     f = tmp_path.joinpath('t.py')
     f.write_text('def test1(): pass\ndef test2(): assert False\n')
-    assert _passed_with_testlist(str(f), 't.py::test2', ['t.py::test1'], []) is False
+    assert _passed_with_testlist(
+        str(f), 't.py::test2', ['t.py::test1'], [],
+    ) is False
 
 
 def test_passed_with_testlist_passing(tmp_path):
     f = tmp_path.joinpath('t.py')
     f.write_text('def test1(): pass\ndef test2(): pass\n')
-    assert _passed_with_testlist(str(f), 't.py::test2', ['t.py::test1'], []) is True
+    assert _passed_with_testlist(
+        str(f), 't.py::test2', ['t.py::test1'], [],
+    ) is True
 
 
 def test_format_cmd_with_tests():

--- a/tests/detect_test_pollution_test.py
+++ b/tests/detect_test_pollution_test.py
@@ -94,21 +94,21 @@ def test_parse_testids_file(tmp_path):
     f = tmp_path.joinpath('t.json')
     f.write_text('test.py::test1\ntest.py::test2')
 
-    assert _parse_testids_file(f) == ['test.py::test1', 'test.py::test2']
+    assert _parse_testids_file(str(f)) == ['test.py::test1', 'test.py::test2']
 
 
 def test_parse_testids_file_blank_line(tmp_path):
     f = tmp_path.joinpath('t.json')
     f.write_text('test.py::test1\n\ntest.py::test2')
 
-    assert _parse_testids_file(f) == ['test.py::test1', 'test.py::test2']
+    assert _parse_testids_file(str(f)) == ['test.py::test1', 'test.py::test2']
 
 
 def test_discover_tests(tmp_path):
     f = tmp_path.joinpath('t.py')
     f.write_text('def test_one(): pass\ndef test_two(): pass\n')
 
-    assert _discover_tests(f) == ['t.py::test_one', 't.py::test_two']
+    assert _discover_tests(str(f), []) == ['t.py::test_one', 't.py::test_two']
 
 
 @pytest.mark.parametrize(
@@ -128,13 +128,13 @@ def test_common_testpath(inputs, expected):
 def test_passed_with_testlist_failing(tmp_path):
     f = tmp_path.joinpath('t.py')
     f.write_text('def test1(): pass\ndef test2(): assert False\n')
-    assert _passed_with_testlist(f, 't.py::test2', ['t.py::test1']) is False
+    assert _passed_with_testlist(str(f), 't.py::test2', ['t.py::test1'], []) is False
 
 
 def test_passed_with_testlist_passing(tmp_path):
     f = tmp_path.joinpath('t.py')
     f.write_text('def test1(): pass\ndef test2(): pass\n')
-    assert _passed_with_testlist(f, 't.py::test2', ['t.py::test1']) is True
+    assert _passed_with_testlist(str(f), 't.py::test2', ['t.py::test1'], []) is True
 
 
 def test_format_cmd_with_tests():


### PR DESCRIPTION
Allow user pass any argument directly to `pytest` (under the hood).
Example of command:
```shell
detect-test-pollution --fuzz --tests tests -m "not qt_test"
```